### PR TITLE
Add popup limit for invalid taps

### DIFF
--- a/config/screen_config.py
+++ b/config/screen_config.py
@@ -16,6 +16,7 @@ POPUP_FONT_COLOR = 'white'
 POPUP_ERROR_BG_COLOR = 'red'
 POPUP_WARNING_BG_COLOR = 'goldenrod'
 POPUP_DURATION = 1.5
+POPUP_LIMIT = 4
 
 # Tap event pop-up configurations
 TAP_EVENT_BG_COLOR = 'green'

--- a/src/screen/screen.py
+++ b/src/screen/screen.py
@@ -149,7 +149,7 @@ class Screen:
                 write_device_state(self.device_state, self.device_state_path)
                 popup_item = (self.popup_attributes.message_attributes.tap_event_message,
                               self.popup_attributes.event_attributes.tap_event_bg_color)
-            elif status == TapStatus.BAD:
+            elif status == TapStatus.BAD and self.popup_queue.qsize() < POPUP_LIMIT:
                 popup_item = (self.popup_attributes.message_attributes.popup_warning_message,
                               self.popup_attributes.event_attributes.popup_warning_bg_color)
             if popup_item:


### PR DESCRIPTION
## Changes:
- Add popup limit to popup queue

## Considerations:
- There is an issue with the invalid taps having many popups queued, which essentially makes the display inoperable until the queue is empty again. The popup limit aims to avoid these situations.